### PR TITLE
Use HTTP 1.1 for proxied requests

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -84,8 +84,10 @@ http {
         set $cf_forwarded_uri /$3;
       }
 
+      proxy_http_version 1.1;
       proxy_ssl_server_name on;
       proxy_ssl_protocols TLSv1.2;
+      proxy_set_header Connection "";
       proxy_set_header Host $cf_forwarded_host;
       proxy_set_header X-Forwarded-Proto $http_x_forwarded_proto;
       proxy_pass $http_x_forwarded_proto://$http_host$cf_forwarded_uri;


### PR DESCRIPTION
What
----

By default nginx uses HTTP 1.0 for proxied upstreams and HTTP 1.0 does not support keepalives.

If the upstream being proxied uses keepalives then nginx may experience
networking issues.

Set the Connection header to empty, let nginx and the upstream to decide
when to close the underlying TCP connection.

How to review
----

- Read the documentation on [`proxy_http_version`](http://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_http_version)
- Read the documentation on [`proxy_set_header`](http://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_set_header)
- See [this](https://github.com/alphagov/notifications-aws/pull/600) related pull request for GOV.UK Notify doing the same